### PR TITLE
Fix comments containing multiple lines in TOML

### DIFF
--- a/fancy_dataclass/toml.py
+++ b/fancy_dataclass/toml.py
@@ -155,7 +155,8 @@ class TOMLDataclass(DictFileSerializableDataclass, TOMLSerializable, suppress_de
                 # TODO: handle None values (comment with empty RHS)
                 settings = self._field_settings(fld).adapt_to(DictDataclassFieldSettings)
                 if settings.doc is not None:
-                    doc.add(tk.comment(str(settings.doc)))
+                    for line in settings.doc.splitlines():
+                        doc.add(tk.comment(line) if line.strip() else tk.nl())
                 val = NoneProxy() if (val is None) else val
                 if isinstance(val, dict):
                     # to preserve, comments, must convert value from TOMLDocument to Table

--- a/fancy_dataclass/toml.py
+++ b/fancy_dataclass/toml.py
@@ -156,7 +156,7 @@ class TOMLDataclass(DictFileSerializableDataclass, TOMLSerializable, suppress_de
                 settings = self._field_settings(fld).adapt_to(DictDataclassFieldSettings)
                 if settings.doc is not None:
                     for line in settings.doc.splitlines():
-                        doc.add(tk.comment(line) if line.strip() else tk.nl())
+                        doc.add(tk.comment(line))
                 val = NoneProxy() if (val is None) else val
                 if isinstance(val, dict):
                     # to preserve, comments, must convert value from TOMLDocument to Table

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -764,9 +764,10 @@ class TestTOML(TestDict):
             b: int = field(default=2, metadata={'doc': 'b value'})
             c: Annotated[int, Doc('c value')] = 3
             d: Annotated[int, Doc('fake')] = field(default=4, metadata={'doc': 'd value'})
+            e: Annotated[int, Doc('Comment Line 1\nComment Line 2')] = 5 # multi-line Doc string
         obj = DCDoc()
         self._test_serialize_round_trip(obj, tmp_path)
-        assert obj.to_toml_string() == 'a = 1\n# b value\nb = 2\n# c value\nc = 3\n# d value\nd = 4\n'
+        assert obj.to_toml_string() == 'a = 1\n# b value\nb = 2\n# c value\nc = 3\n# d value\nd = 4\n# Comment Line 1\n# Comment Line 2\ne = 5\n'
         @dataclass
         class DCDocOuter(TOMLDataclass):
             string: Annotated[str, Doc('a string')] = 'abc'
@@ -775,7 +776,7 @@ class TestTOML(TestDict):
         obj = DCDocOuter()
         self._test_serialize_round_trip(obj, tmp_path)
         # NOTE: nested gets moved to the end, to prevent parsing ambiguity
-        assert obj.to_toml_string() == '# a string\nstring = "abc"\n# a flag\nflag = false\n\n# nested object\n[nested]\na = 1\n# b value\nb = 2\n# c value\nc = 3\n# d value\nd = 4\n'
+        assert obj.to_toml_string() == '# a string\nstring = "abc"\n# a flag\nflag = false\n\n# nested object\n[nested]\na = 1\n# b value\nb = 2\n# c value\nc = 3\n# d value\nd = 4\n# Comment Line 1\n# Comment Line 2\ne = 5\n'
         @dataclass
         class DCList(TOMLDataclass):
             vals: Annotated[List[int], Doc('a list')]


### PR DESCRIPTION
This PR fixes an issue where using a string with multiple lines as the doc comment for a variable would cause invalid TOML.

Previously it would look like this:
```toml
# Comment Line 1
Comment Line 2
variable = "value"
```
Now it's formatted correctly:
```toml
# Comment Line 1
# Comment Line 2
variable = "value"
```